### PR TITLE
Fixes issue when TOKEN_VALUE starts with the "-"...

### DIFF
--- a/hook.sh
+++ b/hook.sh
@@ -4,7 +4,7 @@ function has_propagated {
     while (( "$#" >= 2 )); do
         local RECORD_NAME="${1}"; shift
         local TOKEN_VALUE="${1}"; shift
-        dig +short "${RECORD_NAME}" IN TXT | grep -q "${TOKEN_VALUE}" || return 1
+        dig +short "${RECORD_NAME}" IN TXT | grep -q \"${TOKEN_VALUE}\" || return 1
     done
     return 0
 }


### PR DESCRIPTION
..which causing grep to think you passed more options and error out.

I had my token starting with `-VQ...` and was seeing errors:

```
 + DNS not propagated. Waiting 30s for record creation and replication...
grep: invalid option -- Q
Usage: grep [OPTION]... PATTERN [FILE]...
Try `grep --help' for more information.
 + DNS not propagated. Waiting 30s for record creation and replication...
grep: invalid option -- Q
Usage: grep [OPTION]... PATTERN [FILE]...
Try `grep --help' for more information.
```
