### PR TITLE
Change generated records to be a fully-qualified name

### DIFF
--- a/hook.sh
+++ b/hook.sh
@@ -50,7 +50,7 @@ Please deploy the following record(s) to validate ownership of ${FIRSTDOMAIN}:
 
 EOF
     for (( i=0; i < "${#RECORDS[@]}"; i+=2 )); do
-        MESSAGE="$(printf '%s\n  %s IN TXT %s\n' "$MESSAGE" "${RECORDS[$i]}" "${RECORDS[$(($i + 1))]}")"
+        MESSAGE="$(printf '%s\n  %s. IN TXT %s\n' "$MESSAGE" "${RECORDS[$i]}" "${RECORDS[$(($i + 1))]}")"
     done
 
     echo "$MESSAGE" | mail -s "$SUBJECT" "$RECIPIENT"
@@ -91,7 +91,7 @@ Progagation has completed for ${FIRSTDOMAIN}. The following record(s) can now be
 EOF
 
     while (( "${#RECORDS}" >= 2 )); do
-        MESSAGE="$(printf '%s\n  %s IN TXT %s\n' "$MESSAGE" "${RECORDS[0]}" "${RECORDS[1]}")"
+        MESSAGE="$(printf '%s\n  %s. IN TXT %s\n' "$MESSAGE" "${RECORDS[0]}" "${RECORDS[1]}")"
         RECORDS=( "${RECORDS[@]:2}" )
     done
 


### PR DESCRIPTION
The records that are generated in the emails (in BIND zone file format) sent out are not qualified, but contain the base domain name appended. If someone makes the the mistake of copying and pasting them unmodified, a record such as this: 

_acme-challenge.www.example.com IN TXT OY_vEOhwblUGunh1JxYby7sR-2Tq9aPgHiz5vluRCxg

will actually be:

_acme-challenge.www.example.com.example.com IN TXT OY_vEOhwblUGunh1JxYby7sR-2Tq9aPgHiz5vluRCxg

when fully qualified. I made a very simple modification to the script to append a '.' to the end of the name, making the name fully qualified and can be copied and pasted into a zone file unmodified.

Alternatively, the generated record could be changed to something like this:

_acme-challenge.www IN TXT OY_vEOhwblUGunh1JxYby7sR-2Tq9aPgHiz5vluRCxg

which would avoid the problem as well.
