### PR TITLE
whitelist implemented hooks

### DIFF
--- a/hook.sh
+++ b/hook.sh
@@ -199,4 +199,7 @@ function unchanged_cert {
     oscp_update "$@"
 }
 
-HANDLER=$1; shift; $HANDLER "$@"
+HANDLER=$1; shift
+if [[ "${HANDLER}" =~ ^(deploy_challenge|clean_challenge|deploy_cert|unchanged_cert)$ ]]; then
+  "$HANDLER" "$@"
+fi


### PR DESCRIPTION
Prevent future schema changes from causing problems. Causes unknown hooks to be ignored instead of throwing an error.

Hopefully fixes #10.

Copypasted from https://github.com/lukas2511/dehydrated/commit/e5452922e9f2c7199274a40fc5c2e2bd54e20f99