### PR TITLE
Check propagation on authoritative nameservers

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ a fully automated solution, consider one of the other options
 ```
 git clone https://github.com/lukas2511/dehydrated
 cd dehydrated
-git clone https://github.com/bennettp123/letsencrypt.sh-email-notify-hook hooks/email-notify
+git clone https://github.com/bennettp123/dehydrated-email-notify-hook hooks/email-notify
 ```
 
 ## Usage

--- a/hook.sh
+++ b/hook.sh
@@ -5,11 +5,13 @@ function has_propagated {
         local RECORD_NAME="${1}"; shift
         local TOKEN_VALUE="${1}"; shift
         local RECORD_DOMAIN=$(echo "${RECORD_NAME}" | cut -d'.' -f 2-)
-        local AUTH_NS=($(dig +short "${RECORD_DOMAIN}" IN NS))
-        while [ -z "$AUTH_NS" ]; do
-            RECORD_DOMAIN=$(echo "${RECORD_DOMAIN}" | cut -d'.' -f 2-)
-            AUTH_NS=($(dig +short "${RECORD_DOMAIN}" IN NS))
-        done
+        if [ ${#AUTH_NS[@]} -eq 0 ]; then
+            local AUTH_NS=($(dig +short "${RECORD_DOMAIN}" IN NS))
+            while [ -z "$AUTH_NS" ]; do
+                RECORD_DOMAIN=$(echo "${RECORD_DOMAIN}" | cut -d'.' -f 2-)
+                AUTH_NS=($(dig +short "${RECORD_DOMAIN}" IN NS))
+            done
+        fi
         for NS in "${AUTH_NS[@]}"; do
             dig +short @"${NS}" "${RECORD_NAME}" IN TXT | grep -q "\"${TOKEN_VALUE}\"" || return 1
         done

--- a/hook.sh
+++ b/hook.sh
@@ -1,10 +1,18 @@
 #!/usr/bin/env bash
 
 function has_propagated {
-    while (( "$#" >= 2 )); do
+    while [ "$#" -ge 2 ]; do
         local RECORD_NAME="${1}"; shift
         local TOKEN_VALUE="${1}"; shift
-        dig +short "${RECORD_NAME}" IN TXT | grep -q "\"${TOKEN_VALUE}\"" || return 1
+        local RECORD_DOMAIN=$(echo "${RECORD_NAME}" | cut -d'.' -f 2-)
+        local AUTH_NS=($(dig +short "${RECORD_DOMAIN}" IN NS))
+        while [ -z "$AUTH_NS" ]; do
+            RECORD_DOMAIN=$(echo "${RECORD_DOMAIN}" | cut -d'.' -f 2-)
+            AUTH_NS=($(dig +short "${RECORD_DOMAIN}" IN NS))
+        done
+        for NS in "${AUTH_NS[@]}"; do
+            dig +short @"${NS}" "${RECORD_NAME}" IN TXT | grep -q "\"${TOKEN_VALUE}\"" || return 1
+        done
     done
     return 0
 }


### PR DESCRIPTION
Currently, hook.sh runs the propagation check (in function `has_propagated`) with whatever nameservers the host server is configured to use.

According to @cpu's comment in lukas2511/dehydrated#359, boulder will check authoritative nameservers for a domain (when validating a DNS challenge), but will pick randomly from all authoritative nameservers listed for the domain. It is probably unlikely that a single server will be configured locally with authoritative nameservers for all domains which may request certificates.

This commit changes the `has_propagated` function of the hook to find all authoritative nameservers for each domain, and checks all of them for the presence of the validation record. This should increase the speed of the check (because we don't have to wait for propagation to reach whatever resolver the local server is using) and reliability of the check (because we check all servers which the CA may verify against).

Additionally, a small change was made to README.md, updating the repo name in the clone instructions.

Changes tested on Ubuntu 16.04.2 LTS.