### PR TITLE
fix AUTH_NS override

### DIFF
--- a/hook.sh
+++ b/hook.sh
@@ -6,13 +6,15 @@ function has_propagated {
         local TOKEN_VALUE="${1}"; shift
         local RECORD_DOMAIN=$(echo "${RECORD_NAME}" | cut -d'.' -f 2-)
         if [ ${#AUTH_NS[@]} -eq 0 ]; then
-            local AUTH_NS=($(dig +short "${RECORD_DOMAIN}" IN NS))
-            while [ -z "$AUTH_NS" ]; do
+            local iAUTH_NS=($(dig +short "${RECORD_DOMAIN}" IN NS))
+            while [ -z "$iAUTH_NS" ]; do
                 RECORD_DOMAIN=$(echo "${RECORD_DOMAIN}" | cut -d'.' -f 2-)
-                AUTH_NS=($(dig +short "${RECORD_DOMAIN}" IN NS))
+                iAUTH_NS=($(dig +short "${RECORD_DOMAIN}" IN NS))
             done
+        else
+           iAUTH_NS=("${AUTH_NS[@]}")
         fi
-        for NS in "${AUTH_NS[@]}"; do
+        for NS in "${iAUTH_NS[@]}"; do
             dig +short @"${NS}" "${RECORD_NAME}" IN TXT | grep -q "\"${TOKEN_VALUE}\"" || return 1
         done
     done

--- a/hook.sh
+++ b/hook.sh
@@ -12,7 +12,7 @@ function has_propagated {
                 iAUTH_NS=($(dig +short "${RECORD_DOMAIN}" IN NS))
             done
         else
-           iAUTH_NS=("${AUTH_NS[@]}")
+           local iAUTH_NS=("${AUTH_NS[@]}")
         fi
         for NS in "${iAUTH_NS[@]}"; do
             dig +short @"${NS}" "${RECORD_NAME}" IN TXT | grep -q "\"${TOKEN_VALUE}\"" || return 1


### PR DESCRIPTION
If unset externally on first run, AUTH_NS correctly populates for the first domain in the HOOK_CHAIN, but will then prevent data from being pulled for following domains in the chain.

Change this to correctly override the internal variable if set externally, but otherwise force all domains to pull their own set of authoritative nameservers.