### PR TITLE
Detect FQDNs implemented with CNAME

### DIFF
--- a/hook.sh
+++ b/hook.sh
@@ -22,6 +22,7 @@ function has_propagated {
         for NS in "${iAUTH_NS[@]}"; do
             dig +short @"${NS}" "${RECORD_NAME}" IN TXT | grep -q "\"${TOKEN_VALUE}\"" || return 1
         done
+        unset iAUTH_NS
     done
     return 0
 }

--- a/hook.sh
+++ b/hook.sh
@@ -4,11 +4,16 @@ function has_propagated {
     while [ "$#" -ge 2 ]; do
         local RECORD_NAME="${1}"; shift
         local TOKEN_VALUE="${1}"; shift
-        local RECORD_DOMAIN=$(echo "${RECORD_NAME}" | cut -d'.' -f 2-)
         if [ ${#AUTH_NS[@]} -eq 0 ]; then
-            local iAUTH_NS=($(dig +short "${RECORD_DOMAIN}" IN NS))
+            local RECORD_DOMAIN=$RECORD_NAME
+            declare -a iAUTH_NS
             while [ -z "$iAUTH_NS" ]; do
                 RECORD_DOMAIN=$(echo "${RECORD_DOMAIN}" | cut -d'.' -f 2-)
+                iAUTH_NS=($(dig +short "${RECORD_DOMAIN}" IN CNAME))
+                if [ -n "$iAUTH_NS" ]; then
+                    unset iAUTH_NS && declare -a iAUTH_NS
+                    continue
+                fi
                 iAUTH_NS=($(dig +short "${RECORD_DOMAIN}" IN NS))
             done
         else


### PR DESCRIPTION
The `has_propagated` function uses dig to check whether a query for the
domain name returns valid data for the NS record type. This works except
when the domain name is implemented as a CNAME record type. When a CNAME
is encountered, dig will return it even if there is no proper NS record.
Needless to say, this leads to severe problems (as the propagation check
will then run against a server which may or may not be able to resolve
the query).

Check first whether the domain name is implemented as CNAME. If it is,
dump the results from dig and continue as if we didn't get any response
at all.